### PR TITLE
Fix PageIdentity guard condition

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -120,7 +120,7 @@ class Hooks implements
 
 		$page = $parser->getPage();
 		$this_page_name = $page !== null ? $this->titleFormatter->getPrefixedText( $page ) : '';
-		$this_page_id = $page instanceof PageIdentity ? $page->getId() : 0;
+		$this_page_id = $page instanceof PageIdentity && $page->canExist() ? $page->getId() : 0;
 		$this_page_link = $parser->getOutput()->getPageProperty( 'defaultlink' );
 		$this_page_slinks = $parser->getOutput()->getExtensionData( 'defaultlinksec' ) ?? [];
 


### PR DESCRIPTION
getId() throws if this is not a page that can exist, so check that as well.